### PR TITLE
Hides the auto-generated post excerpts

### DIFF
--- a/src/templates/Post.jsx
+++ b/src/templates/Post.jsx
@@ -21,7 +21,6 @@ class Post extends Component {
     } = this.props.data.wordpressPost;
 
     const { newerPostSlug, olderPostSlug } = this.props.pageContext;
-    console.log(newerPostSlug, olderPostSlug);
     const { edges } = this.props.data.allWordpressWpComments;
     const comments = edges.map(({ node }) => node);
 
@@ -37,6 +36,16 @@ class Post extends Component {
       <CommentsList comments={comments} />
     ) : null;
 
+    // Need this check because apparently it's impossible for Wordpress
+    // NOT to auto-generate an excerpt if none exists...
+    const excerptMarkup = excerpt.includes('<p>&hellip;</p>') ? null : (
+      <div
+        dangerouslySetInnerHTML={{
+          __html: excerpt,
+        }}
+      />
+    );
+
     return (
       <Layout>
         <SEO title={title} description={excerpt} />
@@ -48,11 +57,7 @@ class Post extends Component {
         />
         <div className={styles.PostDate}>{date}</div>
         {featuredImageMarkup}
-        <div
-          dangerouslySetInnerHTML={{
-            __html: excerpt,
-          }}
-        />
+        {excerptMarkup}
         <hr />
         <div
           className={styles.PostContent}


### PR DESCRIPTION
It's super hard to have WordPress NOT auto-generate excerpts for posts that don't have any. This PR adds a check to hide the auto-generated excerpts. Kinda ugly but ... 🙄 

- https://stackoverflow.com/questions/10081129/why-cant-i-override-wps-excerpt-more-filter-via-my-child-theme-functions
- http://stephanieleary.com/2010/02/take-control-of-your-excerpts/