### PR TITLE
Add `url` to gatsby config

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -87,6 +87,7 @@ module.exports = {
     {
       resolve: 'gatsby-source-wordpress',
       options: {
+        url: process.env.GATSBY_WP_BASE_URL,
         baseUrl: process.env.GATSBY_WP_BASE_URL,
         protocol: process.env.GATSBY_WP_PROTOCOL,
         hostingWPCOM: false,


### PR DESCRIPTION
- Added `url` to config for `gatsby-wordpress`. It used to be `baseUrl` but may have changed (keeping both in for now).

It looks like `gatsby-plugin-wordpress` has changed quite a bit since I last fiddled with it. Might be due time to update everything.